### PR TITLE
make CSwiftIO object available via private interface

### DIFF
--- a/Sources/SwiftIO/AnalogIn.swift
+++ b/Sources/SwiftIO/AnalogIn.swift
@@ -48,7 +48,7 @@ import CSwiftIO
 /// ```
 public final class AnalogIn {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private let info: swift_adc_info_t
 

--- a/Sources/SwiftIO/Counter.swift
+++ b/Sources/SwiftIO/Counter.swift
@@ -27,7 +27,7 @@ import CSwiftIO
 /// but cannot track too long (usually several seconds) in case of overflow.
 public final class Counter {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private var mode: Mode
   private var periodTicks: UInt32

--- a/Sources/SwiftIO/DigitalIn.swift
+++ b/Sources/SwiftIO/DigitalIn.swift
@@ -49,7 +49,7 @@ import CSwiftIO
 /// ```
 public final class DigitalIn {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private let direction: swift_gpio_direction_t = SWIFT_GPIO_DIRECTION_IN
 

--- a/Sources/SwiftIO/DigitalInOut.swift
+++ b/Sources/SwiftIO/DigitalInOut.swift
@@ -67,7 +67,7 @@ import CSwiftIO
 /// ```
 public final class DigitalInOut {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private var directionRawValue: swift_gpio_direction_t
   private var outputModeRawValue: swift_gpio_mode_t

--- a/Sources/SwiftIO/DigitalOut.swift
+++ b/Sources/SwiftIO/DigitalOut.swift
@@ -99,7 +99,7 @@ import CSwiftIO
 /// ```
 public final class DigitalOut {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private let direction: swift_gpio_direction_t = SWIFT_GPIO_DIRECTION_OUT
 

--- a/Sources/SwiftIO/I2C.swift
+++ b/Sources/SwiftIO/I2C.swift
@@ -144,7 +144,7 @@ import CSwiftIO
 /// [MadDrivers](https://github.com/madmachineio/MadDrivers).
 public final class I2C {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private var speedRawValue: UInt32
   private var speed: Speed {

--- a/Sources/SwiftIO/I2S.swift
+++ b/Sources/SwiftIO/I2S.swift
@@ -24,7 +24,7 @@ import CSwiftIO
 /// ```
 public final class I2S {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private var config = swift_i2s_cfg_t()
 

--- a/Sources/SwiftIO/PWMOut.swift
+++ b/Sources/SwiftIO/PWMOut.swift
@@ -91,7 +91,7 @@ import CSwiftIO
 /// an important role.
 public final class PWMOut {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private let info: swift_pwm_info_t
 

--- a/Sources/SwiftIO/SPI.swift
+++ b/Sources/SwiftIO/SPI.swift
@@ -131,7 +131,7 @@ import CSwiftIO
 /// Therefore, you can directly read temperature using the predefined APIs.
 public final class SPI {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private var operation: Operation
 

--- a/Sources/SwiftIO/Timer.swift
+++ b/Sources/SwiftIO/Timer.swift
@@ -70,7 +70,7 @@ import CSwiftIO
 /// }
 /// ```
 public final class Timer {
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private var modeRawValue: swift_timer_type_t
 

--- a/Sources/SwiftIO/UART.swift
+++ b/Sources/SwiftIO/UART.swift
@@ -68,7 +68,7 @@ import CSwiftIO
 ///  ```
 public final class UART {
   private let id: Int32
-  private let obj: UnsafeMutableRawPointer
+  @_spi(SwiftIOPrivate) public let obj: UnsafeMutableRawPointer
 
   private var config: swift_uart_cfg_t
 


### PR DESCRIPTION
Make the underlying CSwiftIO object available via a @_spi(SwiftIOPrivate) interface.

This will be useful for my AsyncSwiftIO library, which needs the underlying file descriptor, and is currently accessing it using reflection (which is a hack).